### PR TITLE
[WIP] Optimize dataloader-worker index enque logic

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -2210,7 +2210,6 @@ class TestIndividualWorkerQueue(TestCase):
         )
         current_worker_idx = 0
         for i, (worker_ids, sample) in enumerate(loader):
-            self.assertEqual(worker_ids.tolist(), [current_worker_idx] * batch_size)
             self.assertEqual(sample.tolist(), list(range(i * batch_size, (i + 1) * batch_size)))
             current_worker_idx += 1
             if current_worker_idx == num_workers:


### PR DESCRIPTION
Currently dataloader adds next indices to worker queues in _try_put_index in a round-robin fashion as below:
```python 
def _try_put_index(self):
    ... 
    for _ in range(self._num_workers):  # find the next active worker, if any
        worker_queue_idx = next(self._worker_queue_idx_cycle)
        if self._workers_status[worker_queue_idx]:
            break
    else:
        return
    
# Add indices to worker with index=worker_queue_idx
```

For datasets accessed from data sources external to the node, it is possible that each worker’s access latency varies a lot and hence some of the workers are faster than the others. In such a scenario, it would be efficient to give next batch of indices to workers which have already finished processing their assigned work. In the current setup, we make each of the workers fetch and process equal amount of training samples leaving faster workers to sit idle, which causes the slowest worker to determine the training time. In the proposed change, after reading data from the data queue, we give next batch of indices to the worker which returned the data instead of picking it in a round robin fashion.

```python 
def _try_put_index(self, worker_queue_idx=None):
    ...
    # if worker which just returned data is active, skip search
    if (worker_queue_idx is None) or (not self._workers_status[worker_queue_idx])
        for _ in range(self._num_workers):  # find the next active worker, if any
        worker_queue_idx = next(self._worker_queue_idx_cycle)
        if self._workers_status[worker_queue_idx]:
            break
    else:
        return
    # Add indices to worker with index=worker_queue_idx
```

To test the performance of this change, we developed a microbenchmark where we add an artificial latency to worker 0 to simulate a scenario of some of the workers being slow. Current round-robin method’s performance drops while the performance remains intact with the fix. These are the results of training ResNet50 on ImageNet dataset using mmclassification library with the microbenchmark.

Batch size: 64
Number of workers per GPU: 8
Number of GPUs: 8



  | Master | Proposed change
-- | -- | --
Artificial Latency for  worker 0(ms) | 500 | 500
Throughput(Images/sec) | 1100.1 | 1906.56065
Epoch Time(mins) | 20.816 | 12.13333
Gain(percent) |   | 41.7115






